### PR TITLE
Using $app instead of $this->app for custom drivers

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -90,7 +90,7 @@ abstract class Manager {
 	 */
 	protected function callCustomCreator($driver)
 	{
-		return $this->customCreators[$driver]($app);
+		return $this->customCreators[$driver]($this->app);
 	}
 
 	/**


### PR DESCRIPTION
When firing the closure for a custom driver a `$app` variable is being passed to the closure, however this variable is not within the scope. It should by using `$this->app` which is defined in a managers constructor.
