### PR TITLE
Remove "use Illuminate\Support\Facade;"

### DIFF
--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -1,7 +1,5 @@
 <?php namespace Illuminate\Support\Facades;
 
-use Illuminate\Support\Facade;
-
 class Mail extends Facade {
 
 	/**


### PR DESCRIPTION
This line causes PHP Fatal error:

```
Cannot use Illuminate\Support\Facade as Facade because the name is already in use in /PROJECT-PATH/vendor/illuminate/support/src/Illuminate/Support/Facades/Mail.php on line 3"
```
