### PR TITLE
Default message format.

### DIFF
--- a/MessageBag.php
+++ b/MessageBag.php
@@ -19,7 +19,7 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	 *
 	 * @var string
 	 */
-	protected $format = '<span class="help-inline">:message</span>';
+	protected $format = ':message';
 
 	/**
 	 * Create a new message bag instance.


### PR DESCRIPTION
I think the default format should contain only the message, like it does in L3. Not everyone is using Twitter Bootstrap.
