### PR TITLE
Prevent overridden error messages in all() method

### DIFF
--- a/MessageBag.php
+++ b/MessageBag.php
@@ -140,7 +140,7 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 
 		foreach ($this->messages as $key => $messages)
 		{
-			$all = array_merge($all, $this->transform($messages, $format, $key));
+			$all[] = $this->transform($messages, $format, $key);
 		}
 
 		return $all;


### PR DESCRIPTION
Prevent overriding error messages that have the same key/rule (for example 'required')

EDIT: This wouldn't make sense if one wants to preserve the rule keys.
