### PR TITLE
Add "coreopsis" to uncountable array

### DIFF
--- a/Pluralizer.php
+++ b/Pluralizer.php
@@ -105,6 +105,7 @@ class Pluralizer {
 		'moose',
 		'chassis',
 		'traffic',
+		'coreopsis',
 	);
 
 	/**


### PR DESCRIPTION
Stumbled across this one on a project. The plural of "coreopsis" is "coreopsis", rather than "coreopses".

http://www.merriam-webster.com/dictionary/coreopsis
