### PR TITLE
Added abstract method getDefaultDriver()

### DIFF
--- a/Manager.php
+++ b/Manager.php
@@ -120,6 +120,13 @@ abstract class Manager {
 	}
 
 	/**
+	 * Get the default driver name
+	 * 
+	 * @return string
+	 */
+	abstract public funciton getDefaultDriver();
+	
+	/**
 	 * Dynamically call the default driver instance.
 	 *
 	 * @param  string  $method


### PR DESCRIPTION
The driver() method calls getDefaultDriver(), but nothing in the class says it should be implemented.
