### PR TITLE
Bugfix for long random strings and more randomness

### DIFF
--- a/Str.php
+++ b/Str.php
@@ -213,7 +213,7 @@ class Str {
 	{
 		$pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
-		return substr(str_shuffle(str_repeat($pool, 5)), 0, $length);
+		return substr(str_shuffle(str_repeat($pool, $length)), 0, $length);
 	}
 
 	/**


### PR DESCRIPTION
Bugfix to allow long random strings (> 5*26) and more randomness (string with length=10 must allow 10 times the same chars)
