### PR TITLE
Require the dependancy on Var-dumper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "ext-mbstring": "*",
         "illuminate/contracts": "5.1.*",
         "doctrine/inflector": "~1.0",
-        "danielstjules/stringy": "~1.8"
+        "danielstjules/stringy": "~1.8",
+        "symfony/var-dumper": "~2.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Currently, when you call dd() currently if you only have the illuminate/support subtree installed in a project, it will throw the following error:

> Fatal error: Class 'Symfony\Component\VarDumper\Dumper\CliDumper' not found in .../vendor/illuminate/support/Debug/Dumper.php on line 16

__It appears all that is needed is to require that Symfony component.__ I'm not sure if 2.6 is the right version.