### PR TITLE
Fixed doc block.

### DIFF
--- a/Collection.php
+++ b/Collection.php
@@ -557,7 +557,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Union the collection with the given items.
      *
      * @param  mixed  $items
-     * @return void
+     * @return static
      */
     public function union($items)
     {


### PR DESCRIPTION
Hi :)
I think this "union" method in the Collection class returns a new static instead of "void".
