### PR TITLE
fix Invalid argument supplied for foreach

### DIFF
--- a/ServiceProvider.php
+++ b/ServiceProvider.php
@@ -81,9 +81,11 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace)
     {
-        foreach ($this->app->config['view']['paths'] as $viewPath) {
-            if (is_dir($appPath = $viewPath.'/vendor/'.$namespace)) {
-                $this->app['view']->addNamespace($namespace, $appPath);
+        if (isset($this->app->config['view']['paths'])) {
+            foreach ($this->app->config['view']['paths'] as $viewPath) {
+                if (is_dir($appPath = $viewPath.'/vendor/'.$namespace)) {
+                    $this->app['view']->addNamespace($namespace, $appPath);
+                }
             }
         }
 


### PR DESCRIPTION
Fix for lumen 
see https://github.com/illuminate/support/commit/cb774cd2ee4e9da73caeed63bf31c2af1b2df4db#diff-60526effbb597a1d665f3f70dbf86240

lumen.ERROR: ErrorException: Invalid argument supplied for foreach() in /vendor/illuminate/support/ServiceProvider.php:84

$this->app->config['view']['paths'] is not set , is not used