### PR TITLE
Fix doctrine/inflector package to a version that supports PHP 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.6.4",
         "ext-mbstring": "*",
-        "doctrine/inflector": "~1.1",
+        "doctrine/inflector": "1.1.*",
         "illuminate/contracts": "5.4.*",
         "paragonie/random_compat": "~1.4|~2.0"
     },


### PR DESCRIPTION
If we allow doctrine/inflector v1.2 to be installed, then Illuminate/Support 5.4.* won't be able to be installed in any PHP 5.6 system, since doctrine/inflector v1.2 requires PHP 7