### PR TITLE
Fix doctrine/inflector version for php 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.6.4",
         "ext-mbstring": "*",
-        "doctrine/inflector": "~1.0",
+        "doctrine/inflector": "1.1",
         "illuminate/contracts": "5.3.*",
         "paragonie/random_compat": "~1.4|~2.0"
     },


### PR DESCRIPTION
doctrine/inflector 1.2 and 1.3 bumps the minimum supported PHP version to 7.0.0.