### PR TITLE
parse error fix

### DIFF
--- a/Arr.php
+++ b/Arr.php
@@ -377,7 +377,7 @@ class Arr
     {
         $results = [];
 
-        [$value, $key] = static::explodePluckParameters($value, $key);
+        list($value, $key) = static::explodePluckParameters($value, $key);
 
         foreach ($array as $item) {
             $itemValue = data_get($item, $value);


### PR DESCRIPTION
This line gives parse errors on some hosts.
While I'm not familiar with that syntax, I assumed it's equivalent to using `list()`.