### PR TITLE
req vlucas/phpdotenv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",
         "illuminate/contracts": "5.9.*",
-        "nesbot/carbon": "^1.26.3 || ^2.0"
+        "nesbot/carbon": "^1.26.3 || ^2.0",
+        "vlucas/phpdotenv": "^3.0"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"


### PR DESCRIPTION
i have error after updates on 5.8
PHP Fatal error: Uncaught Error: Class 'Dotenv\Environment\DotenvFactory' not found in /home/rum/projects/trader-account/vendor/illuminate/support/helpers.php:645