### PR TITLE
Locked doctrine/inflector version 1.1 is still compatible with php 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.6.4",
         "ext-mbstring": "*",
-        "doctrine/inflector": "~1.0",
+        "doctrine/inflector": "1.1",
         "illuminate/contracts": "5.3.*",
         "paragonie/random_compat": "~1.4|~2.0"
     },


### PR DESCRIPTION
doctrine/inflector: ~1.0 will update to the latest version 1.3 which required php 7*, can we lock this to v1.1 which supports php 5?

Cheers