### PR TITLE
L5.7 Added return type to avoid "Parameter must be an array or an object that implements Countable" errors in tests

### DIFF
--- a/Testing/Fakes/MailFake.php
+++ b/Testing/Fakes/MailFake.php
@@ -331,6 +331,6 @@ class MailFake implements Mailer, MailQueue
      */
     public function failures()
     {
-        //
+        return [];
     }
 }


### PR DESCRIPTION
We got this error in our unittests on php 7.2:

```
1) ..redacted..Test::test_notify
count(): Parameter must be an array or an object that implements Countable
```

This fix solves that issue