### PR TITLE
L5.6 Added return type to avoid "Parameter must be an array or an object that implements Countable" errors in tests

### DIFF
--- a/Testing/Fakes/MailFake.php
+++ b/Testing/Fakes/MailFake.php
@@ -317,6 +317,6 @@ class MailFake implements Mailer
      */
     public function failures()
     {
-        //
+        return [];
     }
 }


### PR DESCRIPTION
We got this error in our unittests on php 7.2:

```
1) ..redacted..Test::test_notify
count(): Parameter must be an array or an object that implements Countable
```

This fix solves that issue