### PR TITLE
Do case insensitive search using str::contains

### DIFF
--- a/Str.php
+++ b/Str.php
@@ -166,13 +166,21 @@ class Str
 
     /**
      * Determine if a given string contains a given substring.
+     * When case_sensitive is false, convert all parameters to lower case.
      *
      * @param  string  $haystack
      * @param  string|string[]  $needles
+     * @param  bool $case_sensitive
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $case_sensitive = true )
     {
+        if( ! $case_sensitive )
+        {
+            $haystack = strtoupper( $haystack );
+            $needles = array_map( 'strtoupper', (array) $needles);
+        }
+        
         foreach ((array) $needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;


### PR DESCRIPTION
Initially you can only do case sensitive matching using ` Str::contains` and it only returns true if the matching words or characters are in the same case.
I added an optional `$case_sensitive` variable that is by default `true`. If passed as false the search will be case_insensitive.
`Str::contains( 'I am PICK', [ 'pick'] )  // return false`
`Str::contains( 'I am PICK', [ 'pick'] , false )  // return true`
When `false`, it only converts the needle and haystack to lowercase and continues with the search.