### PR TITLE
Update Optional.php

### DIFF
--- a/Optional.php
+++ b/Optional.php
@@ -17,7 +17,7 @@ class Optional implements ArrayAccess
      *
      * @var mixed
      */
-    protected $value;
+    public $value;
 
     /**
      * Create a new optional instance.


### PR DESCRIPTION
allow public access to `$value`, usage scnearios

- when using `!$model` the value was always truthy & the alternative was testing against an attribute existence ex.`!$model->id`, now we can check if the optional item exists or null against an always available attribute. `!$model->value`

- it wasn't possible to test the instance of the underlaying model inside optional, at least there is no a know-how in the docs or api, now we can ex.`get_class($model->value)`

if all good, you can give me the link to the docs and i will update it as well.