### PR TITLE
adding a getter for putenv indication

### DIFF
--- a/Env.php
+++ b/Env.php
@@ -45,6 +45,16 @@ class Env
     }
 
     /**
+     * Get the indication, if putenv is enabled.
+     *
+     * @return bool
+     */
+    public static function getPutenv()
+    {
+        return self::$putenv;
+    }
+
+    /**
      * Get the environment repository instance.
      *
      * @return \Dotenv\Repository\RepositoryInterface


### PR DESCRIPTION
When a dev disables putenv with `disablePutenv()`, then you can check it's state using this function in places, where `putenv()` is called. So if a dev disables `putenv`, then `putenv` shouldn't be called. Then devs can use Artisan::call on servers, where putenv is generally disabled.