### PR TITLE
Replaced is_numeric() with is_int() because PHPUnit uses strict comparison.

### DIFF
--- a/Testing/Fakes/BusFake.php
+++ b/Testing/Fakes/BusFake.php
@@ -76,7 +76,7 @@ class BusFake implements QueueingDispatcher
             [$command, $callback] = [$this->firstClosureParameterType($command), $command];
         }
 
-        if (is_numeric($callback)) {
+        if (is_int($callback)) {
             return $this->assertDispatchedTimes($command, $callback);
         }
 
@@ -138,7 +138,7 @@ class BusFake implements QueueingDispatcher
             [$command, $callback] = [$this->firstClosureParameterType($command), $command];
         }
 
-        if (is_numeric($callback)) {
+        if (is_int($callback)) {
             return $this->assertDispatchedAfterResponseTimes($command, $callback);
         }
 


### PR DESCRIPTION
`Event::assertDispatched(Example::class, '2')` is Laravel-legal but results in PHPUnit mismatch because PHPUnit performs "===" comparison against non-float values:

```
The expected [App\Jobs\Users\AlertEmailMutated] job was pushed 2 times instead of 2 times.
  Failed asserting that 2 is identical to '2'.
```

Example: https://github.com/alezha/laravel-foobar/blob/master/tests/Feature/UserEmailMutationTest.php#L26