### PR TITLE
Added method for converting number to representational words

### DIFF
--- a/Str.php
+++ b/Str.php
@@ -9,6 +9,7 @@ use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use voku\helper\ASCII;
+use NumberFormatter;
 
 class Str
 {
@@ -903,5 +904,21 @@ class Str
     public static function createUuidsNormally()
     {
         static::$uuidFactory = null;
+    }
+
+    /**
+     * Make a number parsed to words.
+     *
+     * @param  string  $value
+     * @param  string  $locale
+     * @return string
+     */
+    public static function numberToWords($value, $locale = 'en_us'): string
+    {
+        if (! is_numeric($value)) {
+            return false;
+        }
+
+        return numfmt_format(numfmt_create($locale, NumberFormatter::SPELLOUT), $value);
     }
 }


### PR DESCRIPTION
- Method for converting number to representational words. Method accepts two parameters, one for number that should be converted and second for the language in which it should be shown. This can be useful for bank systems or different contracts that people use where except numbers value is presented in words too. 