### PR TITLE
Fix for "Array to string conversion" - Error

### DIFF
--- a/MessageBag.php
+++ b/MessageBag.php
@@ -35,7 +35,10 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
         foreach ($messages as $key => $value) {
             $value = $value instanceof Arrayable ? $value->toArray() : (array) $value;
 
-            $this->messages[$key] = array_unique($value);
+            if(is_array($value))
+                $this->messages[$key] = $value;
+            else
+                $this->messages[$key] = array_unique($value);
         }
     }
 


### PR DESCRIPTION
I noticed a Problem with the Error-Output. For a while now, most of the errors are  "Array to string conversion" errors. Since the location the error occured is not in one of my Classes/Files it seems like there is an error  within this package-class. To fix it I added a short code snippet to confirm if the value is actually an array.

Error Code:
C:\xampp\htdocs\Laravel-Project\vendor\laravel\framework\src\Illuminate\Support\MessageBag.php:38
     34▕     {
     35▕         foreach ($messages as $key => $value) {
     36▕             $value = $value instanceof Arrayable ? $value->toArray() : (array) $value;
     37▕
  ➜  38▕             $this->messages[$key] = array_unique($value);
     39▕         }
     40▕     }

Changed Code Snippet:
if(is_array($value))
                $this->messages[$key] = $value;
            else
                $this->messages[$key] = array_unique($value);