### PR TITLE
Standardization creation of Helpers outside of those supplied by the …

### DIFF
--- a/BaseHelpers.php
+++ b/BaseHelpers.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Support;
+
+abstract class BaseHelpers
+{
+    /**
+     * Handle calls to missing methods on the helper.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        throw new BadMethodCallException(sprintf(
+            'Method %s::%s does not exist.', static::class, $method
+        ));
+    }
+
+    /**
+     * @return New Instance Class.
+     */
+    public static function instance() {
+        return new static();
+    }
+    
+}
+
+?>

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "illuminate/contracts": "^10.0",
         "illuminate/macroable": "^10.0",
         "nesbot/carbon": "^2.62.1",
-        "voku/portable-ascii": "^2.0"
+        "voku/portable-ascii": "^2.0",
+        "rmunate/laravel_helpers": "^1.2"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"


### PR DESCRIPTION
**Why accept this contribution?**
I have worked for many years with Laravel, and I have seen that in almost all projects the Helpers are created in different ways in different paths and folders, I have seen people who start using the Framework that when they see the syntax of a Helper similar to that of a PHP own function try to use the function on another system. After seeing this I wanted to standardize the process of creating Helpers, I would like to provide the feature and that a standard for creating helpers for developing systems, easy to use and implement, can be included in the official documentation.

**Originally created library code repository.**
[https://github.com/rmunate/LaravelHelpers](https://github.com/rmunate/LaravelHelpers)

If my contribution becomes useful, I promise to update the documentation in the framework's helpers section.

**Manual**
# Standard Creation and Use of Helpers within (Laravel PHP Framework) | v1.x
**It's time to standardize how to create and use them**

[**---- Documentación En Español ----**](README_SPANISH.md)

![Logo](https://github.com/rmunate/PHP2JS/assets/91748598/447112ed-7993-4808-bfb8-fd85da3c0010)

## Standard creation and use of helpers within the Laravel framework through classes, a simple, efficient, and elegant way to execute your application's own methods from any class or view.

- Call helpers in the views, components, and classes of your application without needing to instantiate the Helper class.
- Organize your helpers into classes dedicated to managing their functions. Think of it as categories, where you'll have all the helpers organized according to their use.
- Static instantiation without the need to create an object to call any helper.
- Create the categories required by your application and customize the functions.
- If desired, you can directly access the class that contains your methods from controllers.
- Maintain a standard in the process of creating and using helpers within your application. It's time to standardize how to create and use them.

## _Installation via Composer_

```shell
composer require rmunate/laravel_helpers
```

## Ways to Use It
Once you have installed the dependency within your project, you can start the structure of your helpers using the following command:

```shell
php artisan generate:helpers
```

This will create a folder named `Helpers` within `App/` where you will find the suggested standard classes for creating your own helpers. It is recommended to create helpers depending on their category of use.

```css
app/
└── Helpers/ 
    └── General.php
    └── Strings.php
    └── Arrays.php
    //..
```

For example, if you are going to create a function that adjusts text strings according to some application-specific requirement, you should create the method inside the `Strings` class.

The methods you create within the chosen class should always have their method name starting with the first word in lowercase and from the second word in uppercase (camelCase).

```php
<?php

namespace App\Helpers;

use Rmunate\LaravelHelpers\BaseHelpers;

class Strings extends BaseHelpers
{
    public function myMethod() {
        // Your Code…
    }
}
```

Now that you have defined the methods, you can call them from anywhere in your application using the following syntax: start with the word `Helper`, followed by the static call `::`, then write the lowercase name of the helper category, in this case, `strings`, and finally the method name in `PascalCase`.

Example of using the `myMethod` method:

Controllers or Classes:

```php
// Strings is the class, so we'll write its full name in lowercase.
// From the second word onwards, we'll use PascalCase.
Helper::stringsMyMethod();
```

Views or Components:

```php
{{ Helper::stringsMyMethod() }}
```

Similarly, since the place where you write the helpers is a class, you can directly call the class that needs to be extended or imported for use. For this purpose, the `instance()` method is included, and you can use it as follows:

```php
// Import the usage of the class.
use App\Helpers\Strings;

// You can directly call the methods through this static call.
Strings::instance()->myMethod();
```

If you want a category that is not provided by the existing classes, no problem! Just execute the following command to create the new category:

```shell
# Replace "Category" with the name you require
php artisan create:helper Category
```

An efficient, clear, clean, and elegant way to create and manage your own functions.

## Creator
- 🇨🇴 Raúl Mauricio Uñate Castro. (raulmauriciounate@gmail.com)

[![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](https://choosealicense.com/licenses/mit/)





