### PR TITLE
Class "Laravel\SerializableClosure\Support\ReflectionClosure" not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "illuminate/contracts": "^12.0",
         "illuminate/macroable": "^12.0",
         "nesbot/carbon": "^2.72.2|^3.0",
-        "voku/portable-ascii": "^2.0"
+        "voku/portable-ascii": "^2.0",
+        "laravel/serializable-closure": "^1.0"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"


### PR DESCRIPTION
An error occurs when using `illuminate/database` in a non-Laravel project.
I sincerely hope you can fix it. 
Thank you very much.

Error: Class "Error: Class "Laravel\SerializableClosure\Support\ReflectionClosure" not found" not found in vendor\illuminate\support\Onceable.php:66 Stack trace:
#0 vendor\illuminate\support\Onceable.php(34): Illuminate\Support\Onceable::hashFromTrace() #1 vendor\illuminate\database\Eloquent\Concerns\PreventsCircularRecursion.php(29): Illuminate\Support\Onceable::tryFromTrace() #2 vendor\illuminate\database\Eloquent\Model.php(1663): Illuminate\Database\Eloquent\Model->withoutRecursion() #3 admin\app\controller\AccountController.php(85): Illuminate\Database\Eloquent\Model->toArray()